### PR TITLE
Compiler version et exclude info class

### DIFF
--- a/LabJavaIO/pom.xml
+++ b/LabJavaIO/pom.xml
@@ -27,6 +27,7 @@
             <filter>
               <artifact>*:*</artifact>
               <excludes>
+                <exclude>module-info.class</exclude>
                 <exclude>META-INF/MANIFEST.MF</exclude>
                 <exclude>META-INF/LICENSE</exclude>
                 <exclude>META-INF/NOTICE</exclude>
@@ -55,6 +56,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
           <source>11</source>
           <target>11</target>


### PR DESCRIPTION
 Il manquait la version au plugin compiler, nous l'avons ajouté sinon maven ne fonctionnait pas, la balise exclude module-info class a été ajouté, le jar ne buildait pas pas sinon